### PR TITLE
fix: USB flash doesn't override OTA flashed image

### DIFF
--- a/partitions.csv
+++ b/partitions.csv
@@ -1,9 +1,8 @@
 
 # ESP-IDF Partition Table
 # Name,   Type, SubType, Offset,    Size,      Flags
-nvs,      data, nvs,     0x9000,    0x4000,
-otadata,  data, ota,     0xd000,    0x2000,
-phy_init, data, phy,     0xf000,    0x1000,
+nvs,      data, nvs,     0x9000,    0x5000,
+otadata,  data, ota,     0xe000,    0x2000,
 ota_0,    app,  ota_0,   0x10000,   0x1A0000,
 ota_1,    app,  ota_1,   0x1B0000,  0x1A0000,
 spiffs,   data, spiffs,  0x350000,  0xA8000,


### PR DESCRIPTION
The custom partition table was placing the otadata partition at a non-standard
offset (0xd000) which doesn't match the hardcoded location the arduino esp32
platform setup expects it to be when flashing (0xe000) per
https://github.com/espressif/arduino-esp32/blob/master/tools/platformio-build-esp32.py#L332

This means flashing via USB was putting the boot_app0.bin config into the 2nd
half of the otadata partition and then overwriting into the phy_init partition
(which isn't being used anyway), if you'd previously OTA'd and the boot from
ota_1 flag was set in otadata (presumably in the first half that wasn't being
written to), the result was the board continues to boot from ota_1, ignoring
the new code in ota_0!!

Removing the phy_init partition, and making the nvs and otadata partitions
match the arduino framework defaults per
https://github.com/espressif/arduino-esp32/blob/master/tools/partitions/default.csv
(but keeping the size changes to the app partitions and spiffs partition) keeps
everything happy and means that now flashing via USB will correctly overwrite
and OTA state and boot from the newly flashed image in ota_0 regardless of
prior OTA state.