### PR TITLE
Platform upgrade

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -18,14 +18,13 @@ build_flags_basic =
 	'-DLOG_LOCAL_LEVEL=${common.debug_level}'
 
 [env]
-platform = espressif32@3.5
+platform = espressif32@4.4.0
 board = esp32doit-devkit-v1
 board_build.filesystem = littlefs
 board_build.partitions = partitions.csv
 framework = arduino
 lib_ldf_mode = chain+
 lib_deps = 
-  lorol/LittleFS_esp32 @ ^1.0.6
   adafruit/Adafruit SCD30@^1.0.8
   me-no-dev/ESP Async WebServer@^1.2.3
   me-no-dev/AsyncTCP@^1.1.1
@@ -47,6 +46,8 @@ lib_deps =
   fastled/FastLED@3.5.0
   zinggjm/GFX_Root@^2.0.0
   mrfaptastic/ESP32 HUB75 LED MATRIX PANEL DMA Display@^2.0.6
+lib_ignore =
+  LittleFS_esp32
 
 build_flags = ${common.build_flags_basic}
 

--- a/src/configManager.cpp
+++ b/src/configManager.cpp
@@ -3,7 +3,7 @@
 #include <configManager.h>
 
 #include <FS.h>
-#include <LITTLEFS.h>
+#include <LittleFS.h>
 #include <ArduinoJson.h>
 
 // Local logging tag
@@ -32,9 +32,9 @@ Config config;
 #define CONFIG_SIZE 768
 
 void setupConfigManager() {
-  if (!LITTLEFS.begin(true)) {
+  if (!LittleFS.begin(true)) {
     ESP_LOGW(TAG, "LittleFS failed! Already tried formatting.");
-    if (!LITTLEFS.begin()) {
+    if (!LittleFS.begin()) {
       delay(100);
       ESP_LOGW(TAG, "LittleFS failed second time!");
     }
@@ -75,7 +75,7 @@ void logConfiguration(const Config& config) {
 }
 
 boolean loadConfiguration(Config& config) {
-  File file = LITTLEFS.open(CONFIG_FILENAME, "r");
+  File file = LittleFS.open(CONFIG_FILENAME, "r");
   if (!file) {
     ESP_LOGW(TAG, "Could not open config file");
     return false;
@@ -123,12 +123,12 @@ boolean saveConfiguration(const Config& config) {
   ESP_LOGD(TAG, "###################### saveConfiguration");
   logConfiguration(config);
   // Delete existing file, otherwise the configuration is appended to the file
-  if (LITTLEFS.exists(CONFIG_FILENAME)) {
-    LITTLEFS.remove(CONFIG_FILENAME);
+  if (LittleFS.exists(CONFIG_FILENAME)) {
+    LittleFS.remove(CONFIG_FILENAME);
   }
 
   // Open file for writing
-  File file = LITTLEFS.open(CONFIG_FILENAME, "w");
+  File file = LittleFS.open(CONFIG_FILENAME, "w");
   if (!file) {
     ESP_LOGW(TAG, "Could not create config file for writing");
     return false;
@@ -165,7 +165,7 @@ boolean saveConfiguration(const Config& config) {
 // Prints the content of a file to the Serial
 void printFile() {
   // Open file for reading
-  File file = LITTLEFS.open(CONFIG_FILENAME, "r");
+  File file = LittleFS.open(CONFIG_FILENAME, "r");
   if (!file) {
     ESP_LOGW(TAG, "Could not open config file");
     return;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -167,7 +167,7 @@ void setup() {
     printFile();
 }
 
-  Wire.begin(SDA, SCL, I2C_CLK);
+  Wire.begin();
 
   // allow SPS30 to come up
   I2C::initI2C();

--- a/src/trafficLight.cpp
+++ b/src/trafficLight.cpp
@@ -32,6 +32,9 @@ TrafficLight::TrafficLight(Model* _model, uint8_t _pinRed, uint8_t _pinYellow, u
 #define pwmChannelGreen   2
 #define pwmResolution     8
 
+  pinMode(pinRed, OUTPUT);
+  pinMode(pinYellow, OUTPUT);
+  pinMode(pinGreen, OUTPUT);
   ledcSetup(pwmChannelRed, pwmFreq, pwmResolution);
   ledcSetup(pwmChannelYellow, pwmFreq, pwmResolution);
   ledcSetup(pwmChannelGreen, pwmFreq, pwmResolution);
@@ -42,13 +45,10 @@ TrafficLight::TrafficLight(Model* _model, uint8_t _pinRed, uint8_t _pinYellow, u
   ledcWrite(pwmChannelYellow, 0);
   ledcWrite(pwmChannelGreen, 0);
 
-  pinMode(pinRed, OUTPUT);
   ledcWrite(pwmChannelRed, config.ledPwm);
   delay(500);
-  pinMode(pinYellow, OUTPUT);
   ledcWrite(pwmChannelYellow, config.ledPwm);
   delay(500);
-  pinMode(pinGreen, OUTPUT);
   ledcWrite(pwmChannelGreen, config.ledPwm);
   delay(500);
   ledcWrite(pwmChannelRed, 0);


### PR DESCRIPTION
Upgrade the platform version to the latest IDF which includes LittleFS by default, because the library version of LITTLEFS previously incldued wasn't integrating propertly with platformio's uploadfs command...

I had to make a few follow-up changes to deal with some API differences in the new platform/IDF version. I've tested extensively on neopixel/LED model boards and everything is working fine AFAICT. 