### PR TITLE
Don't print a message when reading SCD40

### DIFF
--- a/src/scd40.cpp
+++ b/src/scd40.cpp
@@ -94,8 +94,6 @@ SCD40::~SCD40() {
 
 
 boolean SCD40::readScd40() {
-  this->updateMessageCallback("readScd40");
-
   // check if data is ready
   uint16_t dataReady;
   if (!I2C::takeMutex(pdMS_TO_TICKS(1000))) return false;


### PR DESCRIPTION
This makes the screen flash every few seconds as the message briefly appears
which can be distracting.