### PR TITLE
Support client certificate authentication for MQTT

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -14,6 +14,7 @@
 
 static const char* CONFIG_FILENAME = "/config.json";
 static const char* MQTT_ROOT_CA_FILENAME = "/mqtt_root_ca.pem";
-static const char* MQTT_SERVER_CERT_FILENAME = "/mqtt_server_cert.pem";
+static const char* MQTT_CLIENT_CERT_FILENAME = "/mqtt_client_cert.pem";
+static const char* MQTT_CLIENT_KEY_FILENAME = "/mqtt_client_key.pem";
 
 #endif

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -299,11 +299,17 @@ namespace mqtt {
         ((WiFiClientSecure*)wifiClient)->loadCACert(root_ca_file, root_ca_file.size());
         root_ca_file.close();
       }
-      File server_cert_file = LittleFS.open(MQTT_SERVER_CERT_FILENAME, "r");
-      if (server_cert_file) {
-        ESP_LOGD(TAG, "Loading MQTT server cert from FS (%s)", MQTT_SERVER_CERT_FILENAME);
-        ((WiFiClientSecure*)wifiClient)->loadCertificate(server_cert_file, server_cert_file.size());
-        server_cert_file.close();
+      File client_key_file = LittleFS.open(MQTT_CLIENT_KEY_FILENAME, "r");
+      if (client_key_file) {
+        ESP_LOGD(TAG, "Loading MQTT client key from FS (%s)", MQTT_CLIENT_KEY_FILENAME);
+        ((WiFiClientSecure*)wifiClient)->loadPrivateKey(client_key_file, client_key_file.size());
+				client_key_file.close();
+      }
+      File client_cert_file = LittleFS.open(MQTT_CLIENT_CERT_FILENAME, "r");
+      if (client_cert_file) {
+        ESP_LOGD(TAG, "Loading MQTT client cert from FS (%s)", MQTT_CLIENT_CERT_FILENAME);
+        ((WiFiClientSecure*)wifiClient)->loadCertificate(client_cert_file, client_cert_file.size());
+        client_cert_file.close();
       }
     } else {
       wifiClient = new WiFiClient();


### PR DESCRIPTION
Allow the MQTT connection to be authenticated via a client certificate read from the filesystem.

This also fixes a bug/confusion where a "server" certificate was being passed in to the client certificate method - there is no server cert required, only the CA cert.

The benefit of this method is that an SSL cert can be issued to the device a provisioning/flashing time with a known identity and then not only do we get TLS encrypted communications, but we can use the client identity to make sure it's not stomping on reports from other users, etc through the mosquitto ACL file. 