### PR TITLE
Ensure pio installs required dependencies.

### DIFF
--- a/pio_env.py
+++ b/pio_env.py
@@ -1,0 +1,4 @@
+Import("env")
+
+# Make sure esptool is available if we're in a venv (vscode/ubuntu 23.04+)
+env.Execute("$PYTHONEXE -m pip install esptool")

--- a/platformio.ini
+++ b/platformio.ini
@@ -24,7 +24,7 @@ lib_ldf_mode = chain+
 lib_ignore =
   LittleFS_esp32
 
-lib_deps = 
+lib_deps =
   LittleFS@2.0.0
   adafruit/Adafruit SCD30@^1.0.8
   me-no-dev/ESP Async WebServer@^1.2.3
@@ -55,7 +55,8 @@ build_src_flags = !python git-rev.py
 build_flags =
   '-DSSD1306_NO_SPLASH=1'
 
-extra_scripts = 
+extra_scripts =
+    pio_env.py
     upload_no_build.py
     post:post_build.py
 
@@ -71,4 +72,3 @@ build_flags =
 	'-DLOG_LOCAL_LEVEL=4'
   '-DSHOW_DEBUG_MSGS=1'
   '-DSSD1306_NO_SPLASH=1'
-


### PR DESCRIPTION
The new post_build.py file from f8a731c requires esptool to be in the environment, but pio doesn't appear to install this by default, and vscode/ubuntu 23.04+ run everything in python venv's meaning that even if you have it installed in your general workspace pio can't necessarily find it.

This ensures that esptool is always available in the venv that pio is running in.