### PR TITLE
Support turning off lights below a threshold

### DIFF
--- a/include/configManager.h
+++ b/include/configManager.h
@@ -20,9 +20,11 @@ struct Config {
   bool mqttInsecure;
   uint16_t mqttServerPort;
   uint16_t altitude;
+  uint16_t co2GreenThreshold;
   uint16_t co2YellowThreshold;
   uint16_t co2RedThreshold;
   uint16_t co2DarkRedThreshold;
+  uint16_t iaqGreenThreshold;
   uint16_t iaqYellowThreshold;
   uint16_t iaqRedThreshold;
   uint16_t iaqDarkRedThreshold;

--- a/include/model.h
+++ b/include/model.h
@@ -21,7 +21,7 @@ typedef enum {
 } Measurement;
 
 typedef enum {
-  UNDEFINED = 0,
+  OFF = 0,
   GREEN,
   YELLOW,
   RED,

--- a/src/configManager.cpp
+++ b/src/configManager.cpp
@@ -25,9 +25,11 @@ Config config;
   "mqttInsecure": false,
   "mqttServerPort": 65535,
   "altitude": 12345,
+  "co2GreenThreshold": 0,
   "co2YellowThreshold": 800,
   "co2RedThreshold": 1000,
   "co2DarkRedThreshold": 2000,
+  "iagGreenThreshold": 0,
   "iaqYellowThreshold": 100,
   "iaqRedThreshold": 200,
   "iaqDarkRedThreshold": 300,
@@ -79,9 +81,11 @@ void setupConfigManager() {
 #define DEFAULT_MQTT_INSECURE          false
 #define DEFAULT_DEVICE_ID                  0
 #define DEFAULT_ALTITUDE                   5
+#define DEFAULT_CO2_GREEN_THRESHOLD        0
 #define DEFAULT_CO2_YELLOW_THRESHOLD     700
 #define DEFAULT_CO2_RED_THRESHOLD        900
 #define DEFAULT_CO2_DARK_RED_THRESHOLD  1200
+#define DEFAULT_IAQ_GREEN_THRESHOLD        0
 #define DEFAULT_IAQ_YELLOW_THRESHOLD     100
 #define DEFAULT_IAQ_RED_THRESHOLD        200
 #define DEFAULT_IAQ_DARK_RED_THRESHOLD   300
@@ -127,9 +131,11 @@ void getDefaultConfiguration(Config& config) {
   config.mqttInsecure = DEFAULT_MQTT_INSECURE;
   config.mqttServerPort = DEFAULT_MQTT_PORT;
   config.altitude = DEFAULT_ALTITUDE;
+  config.co2GreenThreshold = DEFAULT_CO2_GREEN_THRESHOLD;
   config.co2YellowThreshold = DEFAULT_CO2_YELLOW_THRESHOLD;
   config.co2RedThreshold = DEFAULT_CO2_RED_THRESHOLD;
   config.co2DarkRedThreshold = DEFAULT_CO2_DARK_RED_THRESHOLD;
+  config.iaqGreenThreshold = DEFAULT_IAQ_GREEN_THRESHOLD;
   config.iaqYellowThreshold = DEFAULT_IAQ_YELLOW_THRESHOLD;
   config.iaqRedThreshold = DEFAULT_IAQ_RED_THRESHOLD;
   config.iaqDarkRedThreshold = DEFAULT_IAQ_DARK_RED_THRESHOLD;
@@ -171,9 +177,11 @@ void logConfiguration(const Config& config) {
   ESP_LOGD(TAG, "mqttInsecure: %s", config.mqttInsecure ? "true" : "false");
   ESP_LOGD(TAG, "mqttPort: %u", config.mqttServerPort);
   ESP_LOGD(TAG, "altitude: %u", config.altitude);
+  ESP_LOGD(TAG, "co2GreenThreshold: %u", config.co2GreenThreshold);
   ESP_LOGD(TAG, "co2YellowThreshold: %u", config.co2YellowThreshold);
   ESP_LOGD(TAG, "co2RedThreshold: %u", config.co2RedThreshold);
   ESP_LOGD(TAG, "co2DarkRedThreshold: %u", config.co2DarkRedThreshold);
+  ESP_LOGD(TAG, "iaqGreenThreshold: %u", config.iaqGreenThreshold);
   ESP_LOGD(TAG, "iaqYellowThreshold: %u", config.iaqYellowThreshold);
   ESP_LOGD(TAG, "iaqRedThreshold: %u", config.iaqRedThreshold);
   ESP_LOGD(TAG, "iaqDarkRedThreshold: %u", config.iaqDarkRedThreshold);
@@ -242,9 +250,11 @@ boolean loadConfiguration(Config& config) {
   config.mqttUseTls = doc["mqttUseTls"] | DEFAULT_MQTT_USE_TLS;
   config.mqttInsecure = doc["mqttInsecure"] | DEFAULT_MQTT_INSECURE;
   config.altitude = doc["altitude"] | DEFAULT_ALTITUDE;
+  config.co2GreenThreshold = doc["co2GreenThreshold"] | DEFAULT_CO2_GREEN_THRESHOLD;
   config.co2YellowThreshold = doc["co2YellowThreshold"] | DEFAULT_CO2_YELLOW_THRESHOLD;
   config.co2RedThreshold = doc["co2RedThreshold"] | DEFAULT_CO2_RED_THRESHOLD;
   config.co2DarkRedThreshold = doc["co2DarkRedThreshold"] | DEFAULT_CO2_DARK_RED_THRESHOLD;
+  config.iaqGreenThreshold = doc["iaqGreenThreshold"] | DEFAULT_IAQ_GREEN_THRESHOLD;
   config.iaqYellowThreshold = doc["iaqYellowThreshold"] | DEFAULT_IAQ_YELLOW_THRESHOLD;
   config.iaqRedThreshold = doc["iaqRedThreshold"] | DEFAULT_IAQ_RED_THRESHOLD;
   config.iaqDarkRedThreshold = doc["iaqDarkRedThreshold"] | DEFAULT_IAQ_DARK_RED_THRESHOLD;
@@ -306,9 +316,11 @@ boolean saveConfiguration(const Config& config) {
   doc["mqttUseTls"] = config.mqttUseTls;
   doc["mqttInsecure"] = config.mqttInsecure;
   doc["altitude"] = config.altitude;
+  doc["co2GreenThreshold"] = config.co2GreenThreshold;
   doc["co2YellowThreshold"] = config.co2YellowThreshold;
   doc["co2RedThreshold"] = config.co2RedThreshold;
   doc["co2DarkRedThreshold"] = config.co2DarkRedThreshold;
+  doc["iaqGreenThreshold"] = config.iaqGreenThreshold;
   doc["iaqYellowThreshold"] = config.iaqYellowThreshold;
   doc["iaqRedThreshold"] = config.iaqRedThreshold;
   doc["iaqDarkRedThreshold"] = config.iaqDarkRedThreshold;

--- a/src/model.cpp
+++ b/src/model.cpp
@@ -16,27 +16,31 @@ Model::Model(modelUpdatedEvt_t _modelUpdatedEvt) {
   this->pm4 = 0;
   this->pm10 = 0;
   this->modelUpdatedEvt = _modelUpdatedEvt;
-  this->status = UNDEFINED;
+  this->status = OFF;
 }
 
 Model::~Model() {}
 
 void Model::updateStatus() {
-  TrafficLightStatus co2Status = UNDEFINED;
+  TrafficLightStatus co2Status = OFF;
   if (this->co2 != 0) {
-    if (this->co2 < config.co2YellowThreshold) {
+    if (this->co2 <= config.co2GreenThreshold) {
+      co2Status = OFF;
+    } else if (this->co2 <= config.co2YellowThreshold) {
       co2Status = GREEN;
-    } else if (this->co2 < config.co2RedThreshold) {
+    } else if (this->co2 <= config.co2RedThreshold) {
       co2Status = YELLOW;
-    } else if (this->co2 < config.co2DarkRedThreshold) {
+    } else if (this->co2 <= config.co2DarkRedThreshold) {
       co2Status = RED;
     } else {
       co2Status = DARK_RED;
     }
   }
-  TrafficLightStatus iaqStatus = UNDEFINED;
+  TrafficLightStatus iaqStatus = OFF;
   if (iaq != 0) {
-    if (iaq <= config.iaqYellowThreshold) {
+    if (iaq <= config.iaqGreenThreshold) {
+      iaqStatus = OFF;
+    } else if (iaq <= config.iaqYellowThreshold) {
       iaqStatus = GREEN;
     } else if (iaq <= config.iaqRedThreshold) {
       iaqStatus = YELLOW;
@@ -133,4 +137,3 @@ uint16_t Model::getPM4() {
 uint16_t Model::getPM10() {
   return this->pm10;
 }
-

--- a/src/mqtt.cpp
+++ b/src/mqtt.cpp
@@ -167,9 +167,11 @@ namespace mqtt {
     doc["mqttUseTls"] = config.mqttUseTls;
     doc["mqttInsecure"] = config.mqttInsecure;
     doc["altitude"] = config.altitude;
+    doc["co2GreenThreshold"] = config.co2GreenThreshold;
     doc["co2YellowThreshold"] = config.co2YellowThreshold;
     doc["co2RedThreshold"] = config.co2RedThreshold;
     doc["co2DarkRedThreshold"] = config.co2DarkRedThreshold;
+    doc["iaqGreenThreshold"] = config.iaqGreenThreshold;
     doc["iaqYellowThreshold"] = config.iaqYellowThreshold;
     doc["iaqRedThreshold"] = config.iaqRedThreshold;
     doc["iaqDarkRedThreshold"] = config.iaqDarkRedThreshold;
@@ -264,7 +266,7 @@ namespace mqtt {
     if (!mqtt_client->publish(topic, msg)) {
       ESP_LOGI(TAG, "publish status msg failed!");
       if (!keepOnFailure) free(statusMessage);
-      // don't free heap, since message will be re-tried      
+      // don't free heap, since message will be re-tried
       return false;
     }
     free(statusMessage);
@@ -335,9 +337,11 @@ namespace mqtt {
       }
       bool rebootRequired = false;
       if (doc.containsKey("altitude")) config.altitude = doc["altitude"].as<int>();
+      if (doc.containsKey("co2GreenThreshold")) config.co2GreenThreshold = doc["co2GreenThreshold"].as<uint16_t>();
       if (doc.containsKey("co2YellowThreshold")) config.co2YellowThreshold = doc["co2YellowThreshold"].as<uint16_t>();
       if (doc.containsKey("co2RedThreshold")) config.co2RedThreshold = doc["co2RedThreshold"].as<uint16_t>();
       if (doc.containsKey("co2DarkRedThreshold")) config.co2DarkRedThreshold = doc["co2DarkRedThreshold"].as<uint16_t>();
+      if (doc.containsKey("iaqGreenThreshold")) config.iaqGreenThreshold = doc["iaqGreenThreshold"].as<uint16_t>();
       if (doc.containsKey("iaqYellowThreshold")) config.iaqYellowThreshold = doc["iaqYellowThreshold"].as<uint16_t>();
       if (doc.containsKey("iaqRedThreshold")) config.iaqRedThreshold = doc["iaqRedThreshold"].as<uint16_t>();
       if (doc.containsKey("iaqDarkRedThreshold")) config.iaqDarkRedThreshold = doc["iaqDarkRedThreshold"].as<uint16_t>();

--- a/src/neopixel.cpp
+++ b/src/neopixel.cpp
@@ -38,7 +38,9 @@ void Neopixel::fill(uint32_t c) {
 void Neopixel::update(uint16_t mask, TrafficLightStatus oldStatus, TrafficLightStatus newStatus) {
   if (oldStatus == newStatus && !(mask & M_CONFIG_CHANGED)) return;
   if (mask & M_CONFIG_CHANGED) this->strip->setBrightness(config.brightness);
-  if (newStatus == GREEN) {
+  if (newStatus == OFF) {
+    fill(this->strip->Color(0, 0, 0)); // off
+  } else if (newStatus == GREEN) {
     fill(this->strip->Color(0, 255, 0)); // Green
   } else if (newStatus == YELLOW) {
     fill(this->strip->Color(255, 70, 0)); // Amber

--- a/src/trafficLight.cpp
+++ b/src/trafficLight.cpp
@@ -55,7 +55,12 @@ TrafficLight::~TrafficLight() {
 
 void TrafficLight::update(uint16_t mask, TrafficLightStatus oldStatus, TrafficLightStatus newStatus) {
   if (oldStatus == newStatus && !(mask & M_CONFIG_CHANGED)) return;
-  if (newStatus == GREEN) {
+  if (newStatus == OFF) {
+    ledcDetachPin(pinGreen);
+    ledcDetachPin(pinYellow);
+    ledcDetachPin(pinRed);
+    ledcWrite(PWM_CHANNEL_LEDS, 0);
+  } else if (newStatus == GREEN) {
     ledcAttachPin(pinGreen, PWM_CHANNEL_LEDS);
     ledcDetachPin(pinYellow);
     ledcDetachPin(pinRed);


### PR DESCRIPTION
Some users want to only display lights when action is required to minimise distraction and visual pollution when all is well (e.g. in a bedroom at night, or an office).

Address this request by adding a lower threshold (green), below which the lights are turned off rather than green being shown anytime the level is below the yellow threshold.

Also contains a minor alignment to the CO2 levels to be <= the thresholds, rather than < to align with the iaq logic.

Arduino JSON size estimator reports the two new values do not increase size above the current 1280 buffer value.

The logic is not implemented for the neopixelMatrix display option because I'm less familiar with that interface and cannot test it, and the logic (at a glance) looks more complex in terms of the display, so it's not clear that the same behaviour is desired with that component anyway. 