### PR TITLE
Support building/tagging variants on branches

### DIFF
--- a/.github/workflows/tagged-release.yml
+++ b/.github/workflows/tagged-release.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Cache pip
         uses: actions/cache@v3
         with:


### PR DESCRIPTION
I'd like to use github to build releases for "variant" firmware that I keep on branches which needs a few tweaks to the current versioning logic.

To allow tagging the same version on different branches, we allow version tags to be suffixed with '-name' (for differentiation in git), and then strip the suffix following '-' in the versioning logic. This allows multiple branches to generate the 'same' version in different variants.

When detecting which branch we're building from we need to look for the origin branch containing the tag, rather than the current method as git builds in a detached HEAD state, and to make this possible we need to set fetch-depth=0 on the checkout.

Finally, to tie it all together we include the branch name in the generated version if the tag was not on the main branch.

Example behaviour after this commit:
BRANCH, TAG => Generated Version
main, v1.0.0 => 1.0.0 (behaviour unchanged)
main, v1.5.0 => 1.5.0 (behaviour unchanged)
foo, v1.0.0 => 1.0.0-[foo] (previously generated 1.0.0, even if the tag was not on the main branch)
bar, v1.0.0-bar => 1.0.0-[bar]

